### PR TITLE
Markdown links

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,7 +1,7 @@
 Building Dreambox
 =================
 
-For information about using Dreambox in your project, see the [usage instructions](https://github.com/goodguyry/dreambox/blob/master/README.md#usage).
+For information about using Dreambox in your project, see the [usage instructions](README.md#usage).
 
 ## Packer test build
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ DreamBox is an open source project. It is licensed using the [GNU General Public
 If you're adding software:
 
 1. Please do your best to make sure the version matches the current version used by DreamHost.
-2. Please create a script (such as what exists in [/bin](bin)) for configuration and installation, including building a Debian package (using `checkinstall`) and `zip`ing it to /pkg.
-3. Please add any necessary post-install setup to [package-setup.sh](../../_config/scripts/package-setup.sh)
+2. Please create a script (such as what exists in [/src](src)) for configuration and installation, including building a Debian package (using `checkinstall`) and `zip`ing it to /pkg.
+3. Please add any necessary post-install setup to [package-setup.sh](scripts/package-setup.sh)
 
 Thanks!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ DreamBox is an open source project. It is licensed using the [GNU General Public
 If you're adding software:
 
 1. Please do your best to make sure the version matches the current version used by DreamHost.
-2. Please create a script (such as what exists in [/bin](https://github.com/goodguyry/dreambox/tree/master/bin)) for configuration and installation, including building a Debian package (using `checkinstall`) and `zip`ing it to /pkg.
-3. Please add any necessary post-install setup to [package-setup.sh](https://github.com/goodguyry/dreambox/blob/master/_config/scripts/package-setup.sh)
+2. Please create a script (such as what exists in [/bin](bin)) for configuration and installation, including building a Debian package (using `checkinstall`) and `zip`ing it to /pkg.
+3. Please add any necessary post-install setup to [package-setup.sh](../../_config/scripts/package-setup.sh)
 
 Thanks!

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ DreamBox
 
 > Recreates the DreamHost shared hosting environment as a Vagrant box.
 
-This project repo is for [building the Dreambox base box](https://github.com/goodguyry/dreambox/blob/master/BUILDING.md). To use this box in a project, see [the usage instructions](#usage) below.
+This project repo is for [building the Dreambox base box](BUILDING.md). To use this box in a project, see [the usage instructions](#usage) below.
 
 ## Features
 
@@ -12,7 +12,7 @@ This project repo is for [building the Dreambox base box](https://github.com/goo
 - Apache - `2.2.22` (CGI/FastCGI)
 - MySQL - `5.5.40`
 
-_Python and Ruby environments are not set up. [Contributions](https://github.com/goodguyry/dreambox/blob/master/CONTRIBUTING.md) are welcome and appreciated._
+_Python and Ruby environments are not set up. [Contributions](CONTRIBUTING.md) are welcome and appreciated._
 
 ## Usage
 
@@ -72,5 +72,5 @@ mysql_secure_installation
 
 ## References
 
-- http://php56.dreamhosters.com
+- http://phpinfo.dreamhosters.com/ (outdated)
 - http://wiki.dreamhost.com/Supported_and_unsupported_technologies


### PR DESCRIPTION
Hey — I changed the links in the markdown files so they are branch-agnostic and include updates for the refactoring you've done in the develop branch so far.

Also php56.dreamhosters.com is dead, so I found the next closest thing.
