### PR TITLE
fixes mysql autostart

### DIFF
--- a/scripts/package-setup.sh
+++ b/scripts/package-setup.sh
@@ -109,6 +109,7 @@ cp support-files/my-medium.cnf /etc/my.cnf
 # Set mysql to start at boot
 echo "Setting mysql to start at boot"
 cp support-files/mysql.server /etc/init.d/mysql.server
+update-rc.d mysql.server defaults
 
 cd - >/dev/null
 


### PR DESCRIPTION
just having the script in init.d doesn't mean it will start at boot. Fixes #9

Test procedure:

```
vagrant destroy test
vagrant up test
vagrant halt test
vagrant up test
vagrant ssh test
mysql
```
