### PR TITLE
Adds initial SSL support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 !packages/*.zip
 *.box
+certs
 web

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,7 @@ Vagrant.configure(2) do |config|
     test.vm.network :private_network, ip: "192.168.56.78"
 
     # Sets up the sync folder
-    test.vm.synced_folder 'web', '/home/db_user/dreambox.com'
+    test.vm.synced_folder 'web', '/home/db_user/dreambox.test'
 
     # Start bash as a non-login shell
     test.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
@@ -49,8 +49,9 @@ Vagrant.configure(2) do |config|
     # Environment variables for automating user_setup
     user_vars = {
       "DREAMBOX_USER_NAME" => "db_user",
-      "DREAMBOX_SITE_ROOT" => "dreambox.com",
-      "DREAMBOX_PROJECT_DIR" => "web"
+      "DREAMBOX_SITE_ROOT" => "dreambox.test",
+      "DREAMBOX_PROJECT_DIR" => "web",
+      "ENABLE_SSL" => true
     }
 
     # Runs user_setup

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,7 +51,7 @@ Vagrant.configure(2) do |config|
       "DREAMBOX_USER_NAME" => "db_user",
       "DREAMBOX_SITE_ROOT" => "dreambox.test",
       "DREAMBOX_PROJECT_DIR" => "web",
-      "ENABLE_SSL" => true
+      "ENABLE_SSL" => true,
     }
 
     # Runs user_setup

--- a/Vagrantfile-example
+++ b/Vagrantfile-example
@@ -5,7 +5,8 @@
 $user_vars = {
   'DREAMBOX_USER_NAME' => 'my-user',      # DreamHost username
   'DREAMBOX_SITE_ROOT' => 'example.com',  # Site root directory
-  'DREAMBOX_PROJECT_DIR' => 'web'         # Relative to project root
+  'DREAMBOX_PROJECT_DIR' => 'web',        # Relative to project root
+  "ENABLE_SSL" => true,                   # Defaults to false
 }
 
 # See https://www.vagrantup.com/docs/vagrantfile/ for

--- a/files/http/httpd-vhosts.conf
+++ b/files/http/httpd-vhosts.conf
@@ -3,8 +3,15 @@
 # /usr/local/apache2/conf/extra/httpd-vhosts.conf
 #
 
+Listen 80
+
 <VirtualHost *:80>
   ServerAdmin webmaster@localhost
+  ServerName dreambox.dev
+
+  SSLEngine off
+  # SSLCertificateFile /usr/local/apache2/conf/apache.crt
+  # SSLCertificateKeyFile /usr/local/apache2/conf/apache.key
 
   DocumentRoot "/usr/local/apache2/htdocs"
 

--- a/files/http/httpd-vhosts.conf
+++ b/files/http/httpd-vhosts.conf
@@ -3,7 +3,7 @@
 # /usr/local/apache2/conf/extra/httpd-vhosts.conf
 #
 
-Listen 80
+# Listen 80
 
 <VirtualHost *:80>
   ServerAdmin webmaster@localhost

--- a/files/ssl_setup
+++ b/files/ssl_setup
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Create the SSL certificate, then finish setup
+
+CERT_COUNTRY='US'
+CERT_STATE='Washington'
+CERT_CITY='Seattle'
+CERT_DEPARTMENT='IT'
+
+if [[ -r "/vagrant/certs/${CERT_NAME}.key" && -r "/vagrant/certs/${CERT_NAME}.crt" ]]; then
+  # Use the saved certs
+  echo "Using saved certs from /vagrant/certs/"
+  cp -f /vagrant/certs/"${CERT_NAME}".* /usr/local/apache2/conf/
+else
+  # Create the certificate
+  openssl req -x509 -nodes -days 365 -newkey rsa:2048 -subj "/C=${CERT_COUNTRY}/ST=${CERT_STATE}/L=${CERT_CITY}/O=${CERT_DEPARTMENT}/CN=${DREAMBOX_SITE_ROOT}" -keyout "/usr/local/apache2/conf/${CERT_NAME}.key" -out "/usr/local/apache2/conf/${CERT_NAME}.crt"
+
+  # Create the certs directory
+  [[ ! -d /vagrant/certs ]] && mkdir /vagrant/certs
+  # Save these for next time
+  cp -f /usr/local/apache2/conf/"${CERT_NAME}".* /vagrant/certs
+  e_catch $? "SSL certificate" --clean
+fi
+
+
+# Update vhost file for SSL
+
+# Listen 443
+sed -i 's/\(Listen\ \)\(80\)/\1443/' $VHOST_CONF
+# <VirtualHost *:443>
+sed -i 's/\*:80/\*:443/' $VHOST_CONF
+# SSLEngine on
+sed -i 's/\(SSLEngine\ \)\w*/\1on/' $VHOST_CONF
+# ServerName
+sed -i s/"\(ServerName\ \)\w*\.\w*"/"\1${DREAMBOX_SITE_ROOT}/" $VHOST_CONF
+# SSLCertificateFile
+sed -i s/'\(#\ \)\(SSLCertificateFile\ \)\(\/usr\/local\/apache2\/conf\/\)\w*\.crt'/"\2\3${CERT_NAME}\.crt"/ $VHOST_CONF
+# SSLCertificateKeyFile
+sed -i s/'\(#\ \)\(SSLCertificateKeyFile\ \)\(\/usr\/local\/apache2\/conf\/\)\w*\.key'/"\2\3${CERT_NAME}\.key"/ $VHOST_CONF
+
+e_catch $? "SSL setup" --clean

--- a/files/ssl_setup
+++ b/files/ssl_setup
@@ -26,16 +26,15 @@ fi
 # Update vhost file for SSL
 
 # Listen 443
-sed -i 's/\(Listen\ \)\(80\)/\1443/' $VHOST_CONF
+sed -i 's/\(#\ \)\(Listen\ \)\(80\)/\2443/' $VHOST_CONF
 # <VirtualHost *:443>
 sed -i 's/\*:80/\*:443/' $VHOST_CONF
 # SSLEngine on
 sed -i 's/\(SSLEngine\ \)\w*/\1on/' $VHOST_CONF
-# ServerName
-sed -i s/"\(ServerName\ \)\w*\.\w*"/"\1${DREAMBOX_SITE_ROOT}/" $VHOST_CONF
 # SSLCertificateFile
 sed -i s/'\(#\ \)\(SSLCertificateFile\ \)\(\/usr\/local\/apache2\/conf\/\)\w*\.crt'/"\2\3${CERT_NAME}\.crt"/ $VHOST_CONF
 # SSLCertificateKeyFile
 sed -i s/'\(#\ \)\(SSLCertificateKeyFile\ \)\(\/usr\/local\/apache2\/conf\/\)\w*\.key'/"\2\3${CERT_NAME}\.key"/ $VHOST_CONF
 
 e_catch $? "SSL setup" --clean
+echo "For best results, add the certificate to your keychain"

--- a/files/user_setup
+++ b/files/user_setup
@@ -217,6 +217,9 @@ if [[ $status -eq 4 ]]; then
   sed -i s/"\/usr\/local\/apache2\/htdocs"/"$ESCAPED_SITE_ROOT"/ $VHOST_CONF;
   e_catch $? "httpd-vhosts.conf update" --clean
 
+  # ServerName
+  sed -i s/"\(ServerName\ \)\w*\.\w*"/"\1${DREAMBOX_SITE_ROOT}/" $VHOST_CONF
+
   # Change ownership to Apache user
   chown -R www-data:www-data "$SITE_ROOT"
   e_catch $? "Permissions update" --clean
@@ -228,4 +231,3 @@ fi
 echo
 
 [[ $? -lt 1 ]] && echo -e "User setup complete.\n"
-[[ $ENABLE_SSL ]] && echo -e "For best results, add the certificate to your keychain"

--- a/files/user_setup
+++ b/files/user_setup
@@ -100,6 +100,7 @@ if [[ -n $DREAMBOX_USER_NAME && -n $DREAMBOX_SITE_ROOT && -n $DREAMBOX_PROJECT_D
   USER_DIR="$USER_DIR/$USER_NAME"
   SITE_ROOT="$USER_DIR/$DREAMBOX_SITE_ROOT"
   PROJECT_ROOT="/vagrant/$DREAMBOX_PROJECT_DIR"
+  CERT_NAME="${DREAMBOX_SITE_ROOT//\.*/}"
 
   # Setting status to 4 allows for automating in non-interactive shells, such
   # as during Vagrant provisioning
@@ -208,6 +209,9 @@ if [[ $status -eq 4 ]]; then
   # Backup httpd-vhosts.conf
   conf_do -b
 
+  # Create the SSL certificate
+  [[ $ENABLE_SSL ]] && source ssl_setup;
+
   # Set Apache directory
   ESCAPED_SITE_ROOT=$(echo "$SITE_ROOT" | sed 's/\(\W\)/\\\1/g');
   sed -i s/"\/usr\/local\/apache2\/htdocs"/"$ESCAPED_SITE_ROOT"/ $VHOST_CONF;
@@ -224,3 +228,4 @@ fi
 echo
 
 [[ $? -lt 1 ]] && echo -e "User setup complete.\n"
+[[ $ENABLE_SSL ]] && echo -e "For best results, add the certificate to your keychain"

--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -73,9 +73,13 @@ chmod +x /usr/local/bin/php-fastcgi-wrapper
 cp /tmp/files/http/httpd.conf /usr/local/apache2/conf/
 cp /tmp/files/http/httpd-vhosts.conf /usr/local/apache2/conf/extra/
 
-# Copy user setup script to vagrant home
+# Copy user setup script and set as executable
 cp /tmp/files/user_setup /usr/local/bin/user_setup
 chmod +x /usr/local/bin/user_setup
+
+# Copy SSL setup script and set as executable
+cp /tmp/files/ssl_setup /usr/local/bin/ssl_setup
+chmod +x /usr/local/bin/ssl_setup
 
 # Add Apache, PHP and MySQL bins to PATH
 echo "Adding Apache, PHP and MySQL bins to PATH"


### PR DESCRIPTION
Fixes #1

- Adds an `ENABLE_SSL` environment variable for the `user_setup` script
- Adds a script for creating and enabling a SSL certificate
- Saves the certificate and key files to `certs/` for persistence between `up` and `destroy`