### PR TITLE
Org/cleanup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,14 +17,14 @@ Vagrant.configure(2) do |config|
 
   # Development machine
   # Ubuntu 12.04
-  config.vm.define 'dev' do |dev|
+  config.vm.define 'dev', autostart: false do |dev|
     dev.vm.hostname = "dreambox.dev"
     dev.vm.network :private_network, ip: "192.168.12.34"
   end
 
   # Testing machine
   # Fully provisioned and ready to test
-  config.vm.define 'test' do |test|
+  config.vm.define 'test', primary: true do |test|
     test.vm.hostname = "dreambox.test"
     test.vm.network :private_network, ip: "192.168.56.78"
 

--- a/files/motd/10-help-text
+++ b/files/motd/10-help-text
@@ -21,9 +21,12 @@
 #    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 PROJECT_URL='https://github.com/goodguyry/dreambox'
-DOCS_PATH='/blob/master/README.md#usage'
+DOCS_PATH='/wiki'
 ISSUES_PATH='/issues'
+UPGRADE_PATH='/wiki/Upgrading-Dreambox'
 
-printf "\n* Documentation:\n%s\n" "${PROJECT_URL}${DOCS_PATH}"
+printf "\n* Documentation:\n${PROJECT_URL}%s\n" "${DOCS_PATH}"
 
-printf "\n* Issues:\n%s\n\n" "${PROJECT_URL}${ISSUES_PATH}"
+printf "\n* Issues:\n${PROJECT_URL}%s\n" "${ISSUES_PATH}"
+
+printf "\n* >>> If you're experiencing issues after upgrading, please see the upgrade docs:\n${PROJECT_URL}%s\n\n" "${UPGRADE_PATH}"

--- a/files/user_setup
+++ b/files/user_setup
@@ -54,11 +54,6 @@ function e_catch {
 
 # Cleanup and exit
 function clean_and_exit {
-  # Remove the user if it exists
-  if $(getent passwd "$USER_NAME" >/dev/null); then
-    userdel -r "$USER_NAME"
-    e_catch $? "Delete user '$USER_NAME'"
-  fi
   echo
   # Reset httpd-vhosts.conf_original
   conf_do -d


### PR DESCRIPTION
- Sets `test` as primary VM; prevents `dev` autostart
- Removes `userdel` from `user_setup`
- Updates motd with Wiki links