### PR TITLE
Updates SSL config and script

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,11 +25,11 @@ Vagrant.configure(2) do |config|
   # Testing machine
   # Fully provisioned and ready to test
   config.vm.define 'test', primary: true do |test|
-    test.vm.hostname = "dreambox.test"
+    test.vm.hostname = "dreambox.com"
     test.vm.network :private_network, ip: "192.168.56.78"
 
     # Sets up the sync folder
-    test.vm.synced_folder 'web', '/home/db_user/dreambox.test'
+    test.vm.synced_folder 'web', '/home/db_user/dreambox.com'
 
     # Start bash as a non-login shell
     test.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
@@ -49,9 +49,10 @@ Vagrant.configure(2) do |config|
     # Environment variables for automating user_setup
     user_vars = {
       "DREAMBOX_USER_NAME" => "db_user",
-      "DREAMBOX_SITE_ROOT" => "dreambox.test",
+      "DREAMBOX_SITE_ROOT" => "dreambox.com",
       "DREAMBOX_PROJECT_DIR" => "web",
       "ENABLE_SSL" => true,
+      "DREAMBOX_SITE_NAME" => "dreambox.test",
     }
 
     # Runs user_setup

--- a/Vagrantfile-example
+++ b/Vagrantfile-example
@@ -7,6 +7,7 @@ $user_vars = {
   'DREAMBOX_SITE_ROOT' => 'example.com',  # Site root directory
   'DREAMBOX_PROJECT_DIR' => 'web',        # Relative to project root
   "ENABLE_SSL" => true,                   # Defaults to false
+  'DREAMBOX_SITE_NAME' => 'example.dev',  # Use local site's TLD
 }
 
 # See https://www.vagrantup.com/docs/vagrantfile/ for

--- a/files/ssl_setup
+++ b/files/ssl_setup
@@ -13,7 +13,7 @@ if [[ -r "/vagrant/certs/${CERT_NAME}.key" && -r "/vagrant/certs/${CERT_NAME}.cr
   cp -f /vagrant/certs/"${CERT_NAME}".* /usr/local/apache2/conf/
 else
   # Create the certificate
-  openssl req -x509 -nodes -days 365 -newkey rsa:2048 -subj "/C=${CERT_COUNTRY}/ST=${CERT_STATE}/L=${CERT_CITY}/O=${CERT_DEPARTMENT}/CN=${DREAMBOX_SITE_ROOT}" -keyout "/usr/local/apache2/conf/${CERT_NAME}.key" -out "/usr/local/apache2/conf/${CERT_NAME}.crt"
+  openssl req -x509 -nodes -days 365 -newkey rsa:2048 -subj "/C=${CERT_COUNTRY}/ST=${CERT_STATE}/L=${CERT_CITY}/O=${CERT_DEPARTMENT}/CN=*.${CERT_NAME}" -keyout "/usr/local/apache2/conf/${CERT_NAME}.key" -out "/usr/local/apache2/conf/${CERT_NAME}.crt"
 
   # Create the certs directory
   [[ ! -d /vagrant/certs ]] && mkdir /vagrant/certs

--- a/files/user_setup
+++ b/files/user_setup
@@ -95,7 +95,7 @@ if [[ -n $DREAMBOX_USER_NAME && -n $DREAMBOX_SITE_ROOT && -n $DREAMBOX_PROJECT_D
   USER_DIR="$USER_DIR/$USER_NAME"
   SITE_ROOT="$USER_DIR/$DREAMBOX_SITE_ROOT"
   PROJECT_ROOT="/vagrant/$DREAMBOX_PROJECT_DIR"
-  CERT_NAME="${DREAMBOX_SITE_ROOT//\.*/}"
+  CERT_NAME="${DREAMBOX_SITE_NAME}"
 
   # Setting status to 4 allows for automating in non-interactive shells, such
   # as during Vagrant provisioning


### PR DESCRIPTION
This fixes some errors I was getting in DevTools regarding the certificate's Common Name not matching.

- Requires local Common Name be passed (as DREAMBOX_SITE_NAME)
- Uses wildcard for SSL cert's Common Name