### PR TITLE
0.3.0/php versions

### DIFF
--- a/files/vhost.sh
+++ b/files/vhost.sh
@@ -34,8 +34,6 @@ if [[ 'true' == $ssl ]]; then
   sed -i -r 's/(SSLEngine\s)\w*/\1on/' "${vhost_file}";
   # SSLCertificateFile & SSLCertificateKeyFile.
   sed -i -r s/'(#\s)(SSLCertificate.*)(%cert_name%)'/"\2${box_name}"/ "${vhost_file}";
-  # SSLCertificateKeyFile.
-  # sed -i -r s/'(#\s)(SSLCertificateKeyFile.*)(%cert_name%)'/"\2${box_name}\.key"/ "${vhost_file}"
 else
   # Enable the NameVirtualHost on port 80.
   sed -i -r 's/(#\s)(NameVirtualHost\s\*:80)/\2/' "${port_file}";

--- a/templates/class_config.rb
+++ b/templates/class_config.rb
@@ -40,12 +40,12 @@ class Config
     @raw = YAML.load_file(@config_config_file_path)
 
     # Allowed PHP values and associated PHP install directories
-    php_versions = ['5', '7']
-    php_dirs = ['php56', 'php70']
+    php_versions = ['56', '70', '71']
+    php_dirs = ['php56', 'php70', 'php71']
 
     box_defaults = {}
     box_defaults['name'] = 'dreambox'
-    box_defaults['php'] = php_versions.first
+    box_defaults['php'] = php_versions.at(1)
     box_defaults['ssl'] = false
     box_defaults['ssl_enabled'] = false
     box_defaults['hosts'] = []
@@ -56,7 +56,7 @@ class Config
     begin
       raise KeyError unless php_versions.include?(@raw.fetch('php'))
     rescue KeyError => e
-      handle_error(e, "Accepted `php` values are '#{php_versions.first}' and '#{php_versions.last}")
+      handle_error(e, "Accepted `php` values are '#{php_versions.first}', '#{php_versions.at(1)}', and '#{php_versions.last}'")
     end
 
     @raw['php_dir'] = php_dirs[php_versions.index(@raw.fetch('php'))]

--- a/templates/class_config.rb
+++ b/templates/class_config.rb
@@ -168,6 +168,8 @@ class Config
             'vhost_file' => File.join("#{vhosts_dir}", "#{subdomain_name}.conf"),
             'host' => "#{sub}.#{ remove_www(site.fetch('host')) }",
             'ssl' => site.fetch('ssl'), # Inherited from the parent site
+            'php' => site.fetch('php'), # Inherited from the parent site
+            'php_dir' => site.fetch('php_dir'), # Inherited from the parent site
             'box_name' => @config.fetch('name')
           }
           add_host(subdomains[subdomain_name].fetch('host')) if ssl_enabled

--- a/templates/class_config.rb
+++ b/templates/class_config.rb
@@ -54,12 +54,12 @@ class Config
     @raw = box_defaults.merge(@raw)
 
     begin
-      raise KeyError unless @php_versions.include?(@raw.fetch('php'))
+      raise KeyError unless @php_versions.include?(@raw.fetch('php').to_s)
     rescue KeyError => e
       handle_error(e, "Accepted `php` values are '#{@php_versions.first}', '#{@php_versions.at(1)}', and '#{@php_versions.last}'")
     end
 
-    @raw['php_dir'] = @php_dirs[@php_versions.index(@raw.fetch('php'))]
+    @raw['php_dir'] = @php_dirs[@php_versions.index(@raw.fetch('php').to_s)]
 
     required_properties = ['user', 'root', 'local_root', 'host']
     @raw['sites'].each_key do |dict|
@@ -119,7 +119,12 @@ class Config
       # PHP Version
       # Collect the root PHP version unless the site's version is set
       # Set the `php_dir` based on the collected PHP version
-      site['php'] = @config.fetch('php') unless site.key?('php')
+      site['php'] =
+        if site.key?('php')
+          site.fetch('php').to_s
+        else
+          @config.fetch('php').to_s
+        end
       site['php_dir'] = @php_dirs[@php_versions.index(site.fetch('php'))]
 
       # Paths

--- a/templates/utilities.rb
+++ b/templates/utilities.rb
@@ -54,6 +54,8 @@ module Helpers
       printf "%-20s %s\n", 'user', items['user']
       printf "%-20s %s\n", 'uid', items['uid']
       printf "%-20s %s\n", 'group', items['group']
+      printf "%-20s %s\n", 'php', items['php']
+      printf "%-20s %s\n", 'php_dir', items['php_dir']
       printf "%-20s %s\n", 'gid', items['gid']
       printf "%-20s %s\n", 'root_path', items['root_path']
       printf "%-20s %s\n", 'root', items['root']

--- a/tests/assertions/php.rb
+++ b/tests/assertions/php.rb
@@ -7,52 +7,64 @@
 
   ## ===> Default (Missing)
 
-  # Condition;
+  # Condition:
   # - The root `php` property is not declared.
   #
   # Expected Outcome:
-  # - The root `php` value should default to '5'.
+  # - The root `php` value should default to '70'.
   {
-    'name' => "Missing PHP: The root `php` value should default to '5'.",
-    'expect' => '5',
+    'name' => "Missing PHP: The root `php` value should default to '70'.",
+    'expect' => '70',
     'actual' => @tests.the['required'].config['php'],
   },
 
-  # Condition;
+  # Condition:
   # - The root `php` property is not declared.
   #
   # Expected Outcome:
-  # - The root `php_dir` property created by Config should default to 'php56'.
+  # - The root `php_dir` property created by Config should default to 'php70'.
   {
-    'name' => "Missing PHP: The root `php_dir` property should default to 'php56'.",
-    'expect' => 'php56',
+    'name' => "Missing PHP: The root `php_dir` property should default to 'php70'.",
+    'expect' => 'php70',
     'actual' => @tests.the['required'].config['php_dir'],
   },
 
-  ## ===> PHP 5
+  ## ===> PHP 71
 
-  # Condition;
-  # - The root `php` value is '5'.
+  # Condition:
+  # - The root `php` value is '71'.
   #
   # Expected Outcome:
   # - The root `php_dir` value should match the config version.
   {
-    'name' => "PHP 5: The root `php_dir` value should match the config version.",
-    'expect' => 'php56',
-    'actual' => @tests.the['typical'].config['php_dir'],
+    'name' => "PHP 71: The root `php_dir` value should match the config version.",
+    'expect' => 'php71',
+    'actual' => @tests.the['full'].config['php_dir'],
   },
 
-  ## ===> PHP 7
+  ## ===> Inherited or Overridden
 
-  # Condition;
-  # - The root `php` value is '7'.
+  # Conditions:
+  # - The root `php` value is '71'.
+  # - The site `php` value is '56'.
   #
   # Expected Outcome:
-  # - The root `php_dir` value should match the config version.
+  # - The site's `php_dir` value should match the site's version.
   {
-    'name' => "PHP 7: The root `php_dir` value should match the config version.",
+    'name' => "PHP 56: The site's `php_dir` value should override the root value.",
+    'expect' => 'php56',
+    'actual' => @tests.the['full'].config['sites']['full-one']['php_dir'],
+  },
+
+  # Condition:
+  # - The root `php` property is not declared.
+  #
+  # Expected Outcome:
+  # - The site `php_dir` property should inherit the default version from the root.
+  {
+    'name' => "PHP 70: The site's `php_dir` value should override the root value.",
     'expect' => 'php70',
-    'actual' => @tests.the['full'].config['php_dir'],
+    'actual' => @tests.the['required'].config['sites']['required']['php_dir'],
   },
 
 ])

--- a/tests/assertions/php.rb
+++ b/tests/assertions/php.rb
@@ -49,11 +49,23 @@
   # - The site `php` value is '56'.
   #
   # Expected Outcome:
-  # - The site's `php_dir` value should match the site's version.
+  # - The site's `php_dir` value should override the root value.
   {
-    'name' => "PHP 56: The site's `php_dir` value should override the root value.",
+    'name' => "PHP Override: The site's `php_dir` value should override the root value.",
     'expect' => 'php56',
     'actual' => @tests.the['full'].config['sites']['full-one']['php_dir'],
+  },
+
+  # Conditions:
+  # - The root `php` value is '71'.
+  # - The site `php` value is '56'.
+  #
+  # Expected Outcome:
+  # - The site's `php` value should match the site's version.
+  {
+    'name' => "PHP Override: The site's `php` value should match the site's version.",
+    'expect' => '56',
+    'actual' => @tests.the['full'].config['sites']['full-one']['php'],
   },
 
   # Condition:
@@ -62,7 +74,7 @@
   # Expected Outcome:
   # - The site `php_dir` property should inherit the default version from the root.
   {
-    'name' => "PHP 70: The site's `php_dir` value should override the root value.",
+    'name' => "Missing PHP: The site's `php_dir` value should override the root value.",
     'expect' => 'php70',
     'actual' => @tests.the['required'].config['sites']['required']['php_dir'],
   },

--- a/tests/assertions/php.rb
+++ b/tests/assertions/php.rb
@@ -79,4 +79,17 @@
     'actual' => @tests.the['required'].config['sites']['required']['php_dir'],
   },
 
+  ## ===> Multiple value types for PHP
+
+  # Condition:
+  # - The site `php` value is 56 (non-string value).
+  #
+  # Expected Outcome:
+  # - A PHP value declared as a number should be converted to a string.
+  {
+    'name' => "PHP Number: A PHP value declared as a number should be converted to a string.",
+    'expect' => '56',
+    'actual' => @tests.the['typical'].config['sites']['typical-one']['php'],
+  },
+
 ])

--- a/tests/configs/full.yaml
+++ b/tests/configs/full.yaml
@@ -1,15 +1,17 @@
 # Test configuration featuring multiple sites with full feature set
 #
-# The hosts list should contain only the first site's host,
-# aliases and subdomains, because:
-# - Only one site is missing an `ssl` setting, so the site
-#   inherits the root SSL value.
-# - There is a host declared on the config root `host`
+# The root SSL setting isinherited by the first site, but overridden by
+#   the second site's SSL setting.
+#
+# The root PHP version is overridden by the first site's PHP setting,but
+#   inherited by the second site.
+#
+# There is a host declared on the config root `host`
 #   property, so the site's host doesn't need to be repurposed
 #   as the root host.
 
 name: 'dreambox-tests'
-php: '7'
+php: '71'
 ssl: false
 host: main-host.dev
 
@@ -17,6 +19,7 @@ sites:
   'full-one':
     user: user
     group: shared_group
+    php: '56'
     root: example.com
     public: public
     local_root: web/

--- a/tests/configs/required.yaml
+++ b/tests/configs/required.yaml
@@ -1,7 +1,7 @@
 # Test configuration featuring only required settings
 #
 # The box defaults will be inherited by this config:
-# - PHP version 5
+# - PHP version 70
 # - SSL disabled
 # - 'dreambox' box name
 

--- a/tests/configs/typical.yaml
+++ b/tests/configs/typical.yaml
@@ -13,7 +13,7 @@ sites:
   'typical-one':
     user: user
     group: example_group
-    php: '56'
+    php: 56
     root: example.com
     local_root: web/
     host: example.dev

--- a/tests/configs/typical.yaml
+++ b/tests/configs/typical.yaml
@@ -1,16 +1,19 @@
 # Test configuration featuring a typical setup
 #
-# The root host inherit the first SSL-enabled host declared. The
-# hosts list should contain only SSL-enabled aliases.
+# The root SSL setting isinherited by the first site, but overridden by
+#   the second site's SSL setting.
+#
+# The root PHP version defaults to 70 and is inherited by the second site,
+#   but is overridden by the first site's PHP setting,
 
 name: 'dreambox-tests'
-php: '5'
 ssl: true
 
 sites:
   'typical-one':
     user: user
     group: example_group
+    php: '56'
     root: example.com
     local_root: web/
     host: example.dev

--- a/vm-config.yml
+++ b/vm-config.yml
@@ -1,24 +1,25 @@
 name: 'dreambox'
-# php: '71'
-# ssl: true
+php: '71'
+ssl: true
 
 sites:
   'dreambox':
     user: 'db_user' # required
     root: 'dreambox.com' # required
-    # public: 'public'
+    public: 'public'
     local_root: 'static/' # required
     host: 'www.dreambox.test' # required
-    # aliases:
-    #   - 'dreambox.test'
-    # subdomains:
-    #   app: 'app/'
-  # 'example':
-  #   user: example_user
-  #   root: example.com
-  #   local_root: web
-  #   host: example.dev
-  #   subdomains: { 'help': '/app/help/' }
-  #   ssl: false
+    aliases:
+      - 'dreambox.test'
+    subdomains:
+      app: 'app/'
+  'example':
+    user: example_user
+    php: '56'
+    root: example.com
+    local_root: web
+    host: example.dev
+    subdomains: { 'help': '/app/help/' }
+    ssl: false
 
-# debug: true
+debug: true

--- a/vm-config.yml
+++ b/vm-config.yml
@@ -1,5 +1,5 @@
 name: 'dreambox'
-php: '71'
+php: 71
 ssl: true
 
 sites:

--- a/vm-config.yml
+++ b/vm-config.yml
@@ -1,5 +1,5 @@
 name: 'dreambox'
-# php: '7'
+# php: '71'
 # ssl: true
 
 sites:


### PR DESCRIPTION
* Adds options for the third PHP version (`71`)
* Collects PHP version at the site level as well as at the root (inherits and overrides)
* Allows PHP values to be a Number or String