### PR TITLE
v0.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ DreamBox
 
 > Recreates the DreamHost shared hosting environment as a Vagrant box.
 
-**Version 0.2.x contains breaking changes to the Vagrantfile setup. See [upgrading Dreambox][upgrading_dreambox] for more information.**
+**If you'd like to help test Dreambox 0.3.0-beta, please see [the 0.3.0 configuration notes](../../wiki/0.3.0) in the Wiki**
 
 This project repo contains the code for [building the Dreambox base box][wiki_build]. To use Dreambox in your project, check out the ["Getting Started" section of the Wiki][getting_started].
 

--- a/build
+++ b/build
@@ -17,7 +17,7 @@ rm -f _builds/*
 [[ $(vagrant box remove --force --all dreambox_pre/vmware 2> /dev/null) ]] || echo "No Vagrant box to remove..."
 
 # Build
-packer build -force -var-file=templates/common.json templates/dreambox.json
+packer build -force -parallel=false -var-file=templates/common.json templates/dreambox.json;
 
 # Add the box to vagrant as 'dreambox_pre'
 vagrant box add --force dreambox_pre/virtualbox _builds/dreambox.virtualbox.*.box

--- a/files/motd/10-help-text
+++ b/files/motd/10-help-text
@@ -24,9 +24,15 @@ PROJECT_URL='https://github.com/goodguyry/dreambox'
 DOCS_PATH='/wiki'
 ISSUES_PATH='/issues'
 UPGRADE_PATH='/wiki/Upgrading-Dreambox'
+BETA_DOCS='/wiki/0.3.0'
 
 printf "\n* Documentation:\n${PROJECT_URL}%s\n" "${DOCS_PATH}"
 
 printf "\n* Issues:\n${PROJECT_URL}%s\n" "${ISSUES_PATH}"
 
 printf "\n* >>> If you're experiencing issues after upgrading, please see the upgrade docs:\n${PROJECT_URL}%s\n\n" "${UPGRADE_PATH}"
+
+printf "****"
+printf "\n* 0.3.0-beta now available for testing!"
+printf "\n* Version 0.3.0-beta documentation:\n*   ${PROJECT_URL}%s" "${BETA_DOCS}"
+printf "\n****\n"

--- a/templates/common.json
+++ b/templates/common.json
@@ -1,6 +1,6 @@
 {
   "boot_wait": "10s",
-  "box_version": "0.2.4",
+  "box_version": "0.2.5",
   "description": "A Vagrant environment based on DreamHost's shared hosting",
   "disk_size": "20480",
   "headless": "true",


### PR DESCRIPTION
Adds a message about testing Dreambox `0.3.0-beta-1` and prevents parallel builds (like 0.3.0 will)